### PR TITLE
Use UTF-8 for import and export

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.15-SNAPSHOT'
+def runeLiteVersion = '1.8.21-SNAPSHOT'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/goaltracker/ui/GoalTrackerPanel.java
+++ b/src/main/java/com/goaltracker/ui/GoalTrackerPanel.java
@@ -27,7 +27,7 @@ package com.goaltracker.ui;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.inject.Inject;
-import java.io.FileWriter;
+
 import javax.swing.filechooser.FileNameExtensionFilter;
 import lombok.Getter;
 import com.goaltracker.Goal;
@@ -54,9 +54,13 @@ import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -190,9 +194,10 @@ public class GoalTrackerPanel extends PluginPanel
 					if (confirm != 0) return;
 				}
 
-				try
+				try (FileInputStream fileStream = new FileInputStream(file);
+					InputStreamReader reader = new InputStreamReader(fileStream, StandardCharsets.UTF_8);
+					BufferedReader in = new BufferedReader(reader))
 				{
-					BufferedReader in = new BufferedReader(new FileReader(file));
 					String line = in.readLine();
 					StringBuilder json = new StringBuilder();
 					while (line != null)
@@ -254,13 +259,12 @@ public class GoalTrackerPanel extends PluginPanel
 					file = new File(file.getParentFile(), file.getName() + ".json");
 				}
 
-				try
+				try (FileOutputStream fileStream = new FileOutputStream(file);
+					OutputStreamWriter writer = new OutputStreamWriter(fileStream, StandardCharsets.UTF_8))
 				{
 					final Gson gson = new GsonBuilder().setPrettyPrinting().create();
 					final String json = gson.toJson(plugin.getGoals());
-					FileWriter fw = new FileWriter(file);
-					fw.write(json);
-					fw.close();
+					writer.write(json);
 				}
 				catch (IOException ex)
 				{


### PR DESCRIPTION
Right now, the plugin is using the platform default encoding, which is UTF-8 for Linux and Mac and Windows-1252 for Windows. In today's world, using UTF-8 for all three is the sensible choice.

This enables using characters such as emojis reliably. It also enables sharing the exported file with someone who uses a different OS. For a motivating example, see [Marstead's playthrough](https://youtu.be/W1Y-ar6Enz0?t=1423) (timestamped), where he tries to use emojis as icons for his different categories of goals. 

The Runelite version was also bumped from .15 to .21.

One point of contention, the subsequent lines of the try-with-resources blocks are indented with a single tab, which seemed like the most sensible option given that tabs were being used in the rest of the file. These can be reformatted if there's a preference on how to do so, but aligning the text via spaces will change with different tab widths, which is why it looks so offset on Github, or require the `try (` to be its own line in order to get all the resource lines aligned.